### PR TITLE
Switched to Reduce in mutate_internal

### DIFF
--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -93,19 +93,33 @@ mutate_internal <- function(.data, FUNS, quos) {
                 c("...", ls(all.names = TRUE)))) {
         assign(n, get(n, scope_env), pos = as.environment(-1L))
     }
-    EXPRS <- lapply(names(FUNS), function(x) {
-        FUNS_expl <- with(.data, rlang::eval_tidy(FUNS[[x]]))
-        FUNS_obj <- with(.data, eval(rlang::eval_tidy(FUNS[[x]])))
-        if (!inherits(FUNS_obj, "numeric")) {
-            sprintf("%s <- %s", x, paste0(deparse(FUNS_expl), collapse = ""))
-        } else {
-            sprintf("%s <- c(%s)", x, paste0(FUNS_expl, collapse = ", "))
-        }
-    })
-    S4Vectors::within(ungroup(.data), eval(parse(text = paste0(
-        unlist(EXPRS),
-        collapse = "\n"
-    ))))
+
+    ## Here's a suggestion. I think it will handle the ungrouping OK and
+    ## should pass the columns consecutively
+    Reduce(
+        function(df, nm) {
+            val <- rlang::eval_tidy(FUNS[[nm]], data = as.list(df))
+            df[[nm]] <- val
+            df
+        },
+        x = names(FUNS),
+        init = ungroup(.data)
+    )
+
+    ## Original process. Just commented out for convenience
+    # EXPRS <- lapply(names(FUNS), function(x) {
+    #     FUNS_expl <- with(.data, rlang::eval_tidy(FUNS[[x]]))
+    #     FUNS_obj <- with(.data, eval(rlang::eval_tidy(FUNS[[x]])))
+    #     if (!inherits(FUNS_obj, "numeric")) {
+    #         sprintf("%s <- %s", x, paste0(deparse(FUNS_expl), collapse = ""))
+    #     } else {
+    #         sprintf("%s <- c(%s)", x, paste0(FUNS_expl, collapse = ", "))
+    #     }
+    # })
+    # S4Vectors::within(ungroup(.data), eval(parse(text = paste0(
+    #     unlist(EXPRS),
+    #     collapse = "\n"
+    # ))))
 }
 
 #' @inherit dplyr::tbl_vars


### PR DESCRIPTION
This seems to work for me, but I couldn't get the `test_that` suite to run. Every call to a `GroupedDataFrame` failed with the error `first element used of 'length.out' argument` and I couldn't figure it out. It seems to be an unrelated error though, as I couldn't even get the following to work,

``` r
m <- mtcars
M <- as(m, "GroupedDataFrame")
```

Consequently, I couldn't test on a `GroupedDataFrame`, but I think it will work if I've got the `ungroup()` call right. I didn't benchmark for speed either