### PR TITLE
Changed to Reduce internally for mutate_internal()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,8 @@ Authors@R: c(person("Jonathan", "Carroll",
     email = "rpkg@jcarroll.com.au", 
     role = c("aut", "cre"), 
     comment = c(ORCID = "0000-0002-1404-5264")),
-    person("Pierre-Paul", "Axisa", role=c("ctb")))
+    person("Pierre-Paul", "Axisa", role=c("ctb")),
+    person("Stevie", "Pederson", role=c("ctb")))
 Description: Provides `dplyr` verbs (`mutate`, `select`, `filter`, etc...) 
     supporting `S4Vectors::DataFrame` objects. Importantly, this is achieved 
     without conversion to an intermediate `tibble`. Adds grouping 

--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -93,19 +93,33 @@ mutate_internal <- function(.data, FUNS, quos) {
                 c("...", ls(all.names = TRUE)))) {
         assign(n, get(n, scope_env), pos = as.environment(-1L))
     }
-    EXPRS <- lapply(names(FUNS), function(x) {
-        FUNS_expl <- with(.data, rlang::eval_tidy(FUNS[[x]]))
-        FUNS_obj <- with(.data, eval(rlang::eval_tidy(FUNS[[x]])))
-        if (!inherits(FUNS_obj, "numeric")) {
-            sprintf("%s <- %s", x, paste0(deparse(FUNS_expl), collapse = ""))
-        } else {
-            sprintf("%s <- c(%s)", x, paste0(FUNS_expl, collapse = ", "))
-        }
-    })
-    S4Vectors::within(ungroup(.data), eval(parse(text = paste0(
-        unlist(EXPRS),
-        collapse = "\n"
-    ))))
+
+    ## Here's a suggestion. I think it will handle the ungrouping OK and
+    ## should pass the columns consecutively
+    Reduce(
+        function(df, nm) {
+            val <- rlang::eval_tidy(FUNS[[nm]], data = as.list(df))
+            df[[nm]] <- val
+            df
+        },
+        x = names(FUNS),
+        init = ungroup(.data)
+    )
+
+    ## Original process. Just commented out for convenience
+    # EXPRS <- lapply(names(FUNS), function(x) {
+    #     FUNS_expl <- with(.data, rlang::eval_tidy(FUNS[[x]]))
+    #     FUNS_obj <- with(.data, eval(rlang::eval_tidy(FUNS[[x]])))
+    #     if (!inherits(FUNS_obj, "numeric")) {
+    #         sprintf("%s <- %s", x, paste0(deparse(FUNS_expl), collapse = ""))
+    #     } else {
+    #         sprintf("%s <- c(%s)", x, paste0(FUNS_expl, collapse = ", "))
+    #     }
+    # })
+    # S4Vectors::within(ungroup(.data), eval(parse(text = paste0(
+    #     unlist(EXPRS),
+    #     collapse = "\n"
+    # ))))
 }
 
 #' @inherit dplyr::tbl_vars

--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -81,9 +81,6 @@ mutate.GroupedDataFrame <- function(.data, ...) {
 #' @keywords internal
 #' @importFrom rlang eval_tidy quo_get_env
 mutate_internal <- function(.data, FUNS, quos) {
-    op <- options("useFancyQuotes")
-    on.exit(options(op))
-    options(useFancyQuotes = FALSE)
 
     ## hack: inject the local env with the scoped data,
     ## excluding data that was already here.
@@ -94,8 +91,8 @@ mutate_internal <- function(.data, FUNS, quos) {
         assign(n, get(n, scope_env), pos = as.environment(-1L))
     }
 
-    ## Here's a suggestion. I think it will handle the ungrouping OK and
-    ## should pass the columns consecutively
+    ## columns are processed consecutively, and so can depend on earlier
+    ## columns created via mutations, not only initially available in the data
     Reduce(
         function(df, nm) {
             val <- rlang::eval_tidy(FUNS[[nm]], data = as.list(df))
@@ -106,20 +103,6 @@ mutate_internal <- function(.data, FUNS, quos) {
         init = ungroup(.data)
     )
 
-    ## Original process. Just commented out for convenience
-    # EXPRS <- lapply(names(FUNS), function(x) {
-    #     FUNS_expl <- with(.data, rlang::eval_tidy(FUNS[[x]]))
-    #     FUNS_obj <- with(.data, eval(rlang::eval_tidy(FUNS[[x]])))
-    #     if (!inherits(FUNS_obj, "numeric")) {
-    #         sprintf("%s <- %s", x, paste0(deparse(FUNS_expl), collapse = ""))
-    #     } else {
-    #         sprintf("%s <- c(%s)", x, paste0(FUNS_expl, collapse = ", "))
-    #     }
-    # })
-    # S4Vectors::within(ungroup(.data), eval(parse(text = paste0(
-    #     unlist(EXPRS),
-    #     collapse = "\n"
-    # ))))
 }
 
 #' @inherit dplyr::tbl_vars

--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -331,8 +331,10 @@ group_by.DataFrame <- function(.data,
             }
         }
         uniques <- unique(select(.data, !!!rlang::syms(unlist(groupvars))))
+        i <- nrow(.data)
         flagged <- S4Vectors::merge(
-            mutate(.data, rowid = seq_len(nrow(.data))),
+            mutate(.data, rowid = seq_len(i)),
+            # mutate(.data, rowid = seq_len(nrow(.data))),
             mutate(uniques, flag = seq_len(nrow(uniques))),
             by = unlist(groupvars),
             sort = FALSE

--- a/man/DFplyr-package.Rd
+++ b/man/DFplyr-package.Rd
@@ -55,6 +55,7 @@ Useful links:
 Other contributors:
 \itemize{
   \item Pierre-Paul Axisa [contributor]
+  \item Stevie Pederson [contributor]
 }
 
 }

--- a/man/format.DataFrame.Rd
+++ b/man/format.DataFrame.Rd
@@ -29,7 +29,8 @@ An object of similar structure to \code{x} containing character
   alignment in the collapsed strings.
 }
 \description{
-Format an \R object for pretty printing.
+Format an \R object for pretty printing, notably encoding vector or
+  column elements into a common format.
 }
 \details{
 \code{format} is a generic function.  Apart from the methods described

--- a/tests/testthat/test-mutate.R
+++ b/tests/testthat/test-mutate.R
@@ -11,6 +11,12 @@ test_that("mutate works with regular columns", {
     expect_true("newvar2" %in% names(m))
     expect_identical(m$newvar2, mtcars$cyl^2)
 
+    carletters <- c(LETTERS, LETTERS[1:6])
+    m <- mutate(d, newvar3 = paste0(carletters, cyl))
+    expect_s4_class(m, "DataFrame")
+    expect_true("newvar3" %in% names(m))
+    expect_identical(m$newvar3, paste0(carletters, mtcars$cyl))
+
     m <- mutate_at(d, vars(starts_with("c")), ~ .^2)
     expect_s4_class(m, "DataFrame")
     expect_identical(names(m), names(d))
@@ -33,4 +39,38 @@ test_that("mutate works with S4 columns", {
     expect_true("chr" %in% names(m))
     expect_s4_class(m$chr, "Rle")
     expect_identical(m$chr, IRanges::RleList(factor(rep("chrX", 32)))[[1]])
+})
+
+test_that("mutate adds columns sequentially", {
+  d <- S4Vectors::DataFrame(mtcars)
+  m <- mutate(d, newvar = cyl * 2, newervar = newvar + am)
+  expect_s4_class(m, "DataFrame")
+  expect_true("newvar" %in% names(m))
+  expect_true("newervar" %in% names(m))
+  expect_identical(m$newvar, mtcars$cyl * 2)
+  expect_identical(m$newervar, mtcars$am + mtcars$cyl * 2)
+})
+
+
+test_that("sequential mutation supports groups", {
+  d <- S4Vectors::DataFrame(mtcars) |>
+    group_by(gear)
+  m <- mutate(d,
+              newvar = cyl * 2,
+              avggear = mean(gear) + 1,
+              newervar = vs + newvar + avggear)
+  expect_s4_class(m, "DataFrame")
+  expect_s4_class(m, "GroupedDataFrame")
+  expect_true("newvar" %in% names(m))
+  expect_true("avggear" %in% names(m))
+  expect_true("newervar" %in% names(m))
+
+  # realign rows after grouping
+  mm <- m[rownames(mtcars), ]
+  expect_identical(mm$newvar, mtcars$cyl * 2)
+  expect_identical(mm$avggear, mtcars$gear + 1)
+  expect_identical(mm$newervar,
+                   mtcars$vs +
+                     (mtcars$gear + 1) +
+                     (mtcars$cyl * 2))
 })

--- a/vignettes/example_usage.Rmd
+++ b/vignettes/example_usage.Rmd
@@ -106,6 +106,14 @@ or calculating the `length()` of the `nl` column cells as `length_nl`
 mutate(d, length_nl = lengths(nl))
 ```
 
+The to-be-created columns can reference other columns that appear only in the 
+call being made and not in the input data, e.g. the `gear2` column can be 
+referenced in a subsequent calculation
+
+```{r "subsequent"}
+mutate(d, gear2 = gear * 2, later = gear2 * 3)
+```
+
 Transformations can involve S4-related functions, such as extracting the 
 `seqnames()`, `strand()`, and `end()` of the `grX` column
 


### PR DESCRIPTION
This originally worked nicely, but created a downstream bug in `group_by.DataFrame()` where passing `nrow(.data)` to mutate couldn't find the object `.data`. I've simply added a line in this function finding the number of rows before the call. Everything in `test_that()` and `R CMD check` now seems to pass